### PR TITLE
Fix syntax error in tts/main.js

### DIFF
--- a/wrapper/tts/main.js
+++ b/wrapper/tts/main.js
@@ -10,7 +10,7 @@ const http = require("http");
 let get;
 try {
 	get = require("../misc/get");
-} catch {
+} catch (e) {
 	get = require("./get");
 }
 


### PR DESCRIPTION
Some instances of javascript require an error argument to be present on a `catch` or there will be a syntax error and the whole program will abort.