### PR TITLE
Chromium allow plugins parameter in all instances

### DIFF
--- a/start_wrapper.bat
+++ b/start_wrapper.bat
@@ -753,9 +753,9 @@ if !INCLUDEDCHROMIUM!==n (
 	echo Opening Wrapper: Offline using included Chromium...
 	pushd utilities\ungoogled-chromium
 	if !APPCHROMIUM!==y (
-		if !DRYRUN!==n ( start chrome.exe --user-data-dir=the_profile --app=http://localhost:4343 )
+		if !DRYRUN!==n ( start chrome.exe --allow-outdated-plugins --user-data-dir=the_profile --app=http://localhost:4343 )
 	) else (
-		if !DRYRUN!==n ( start chrome.exe --user-data-dir=the_profile http://localhost:4343 )
+		if !DRYRUN!==n ( start chrome.exe --allow-outdated-plugins --user-data-dir=the_profile http://localhost:4343 )
 	)
 	popd
 )
@@ -838,9 +838,9 @@ if !INCLUDEDCHROMIUM!==n (
 	echo Opening Wrapper: Offline using included Chromium...
 	pushd utilities\ungoogled-chromium
 	if !APPCHROMIUM!==y (
-		start chrome.exe --user-data-dir=the_profile --app=http://localhost:4343 >nul
+		start chrome.exe --allow-outdated-plugins --user-data-dir=the_profile --app=http://localhost:4343 >nul
 	) else (
-		start chrome.exe --user-data-dir=the_profile http://localhost:4343 >nul
+		start chrome.exe --allow-outdated-plugins --user-data-dir=the_profile http://localhost:4343 >nul
 	)
 	popd
 )
@@ -859,9 +859,9 @@ if !INCLUDEDCHROMIUM!==n (
 	echo Opening the server page using included Chromium...
 	pushd utilities\ungoogled-chromium
 	if !APPCHROMIUM!==y (
-		start chrome.exe --user-data-dir=the_profile --app=https://localhost:4664 >nul
+		start chrome.exe --allow-outdated-plugins --user-data-dir=the_profile --app=https://localhost:4664 >nul
 	) else (
-		start chrome.exe --user-data-dir=the_profile https://localhost:4664 >nul
+		start chrome.exe --allow-outdated-plugins --user-data-dir=the_profile https://localhost:4664 >nul
 	)
 	popd
 )


### PR DESCRIPTION
A previous 1.2.3 commit has removed all instances of the allow plugins parameter, then another commit added it back in only 1 out of 7 instances of the Chromium command line. I am readding the parameter back so users will not have to confirm the use of plugins every single time they try to use the video maker, character creator, character browser, or player.