### PR TITLE
Catch exceptions for VoiceForge voices

### DIFF
--- a/wrapper/models/tts.js
+++ b/wrapper/models/tts.js
@@ -142,7 +142,7 @@ module.exports = function processVoice(voiceName, rawText) {
 						}
 					}, (r) => {
 						convertToMp3(r, "wav").then(res).catch(rej);
-					});
+					}).on("error", rej);
 					break;
 				}
 


### PR DESCRIPTION
Network errors in VoiceForge voices can crash Wrapper Offline as of now. This PR adds some exception handling to VoiceForge voices.